### PR TITLE
Style: Fix product card to have the same size

### DIFF
--- a/src/components/ResultTable/Card/Card.css
+++ b/src/components/ResultTable/Card/Card.css
@@ -4,6 +4,9 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    max-width: 300px;
+    height: 100%;
+    width: 100%;
 }
 
 .CardContainer .ProductImageContainer {

--- a/src/components/ResultTable/Card/Detail/Detail.css
+++ b/src/components/ResultTable/Card/Detail/Detail.css
@@ -4,4 +4,5 @@
     border-bottom-left-radius: 10px;
     border-bottom-right-radius: 10px;
     padding: 23px;
+    height: 180px;
 }


### PR DESCRIPTION
## Context
The card for each product didn't have the same size, damaging the app's UI
## Changes
The card is made up of two parts: One for the image and the other for the description.
- Fixed description size
- Fixed card size
## Screenshot
![image](https://github.com/MarcoAguirre/ioet-university-e-commerce/assets/42116904/2b87a6fd-ed1e-4c04-b4a7-4b33e29edaa2)
